### PR TITLE
Bugfix: feedItem is not defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ module.exports = function (eleventyConfig) {
 }
 ```
 
-This adds a new Global Data entry called `mydata`, which contains an array with the following properties:
+This adds a new Global Data entry called `readinglist`, which contains an array with the following properties:
 
 ```javascript
 {
@@ -57,4 +57,12 @@ e.g.
 		]
 	}
 ]
+```
+
+Paste the following code in your template to display available data as stringified JSON objects:
+
+```
+{% for data in readinglist %}
+{{ data | dump }}<br/><br/><br/>
+{% endfor %}
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,8 @@ const getBook = async (url) => {
 
 const getMessage = async (message) => {
 	try {
-		const book = await getBook(message?.tag?.[0]?.href);
+		const url = message?.tag?.[0]?.href;
+		const book = await getBook(url);
 
 		return {
 			book,
@@ -48,7 +49,7 @@ const getMessage = async (message) => {
 			status: message.content.replace( /(<([^>]+)>)/ig, ''),
 		};
 	} catch (e) {
-		console.error(`[eleventy-plugin-bookywyrm] Error occurred when parsing ${feedItem.link}: ${e.message}`);
+		console.error(`[eleventy-plugin-bookywyrm] Error occurred when parsing ${url}: ${e.message}`);
 	}
 }
 


### PR DESCRIPTION
Hi!

Last evening [Chris tried to use your plugin to fetch his Bookwyrm list](https://mastodon.social/@Chris/111293912343145492) and he couldn't get it to work. I cloned the repo, gave it a brief look and found out the plugin fails the build process due to a reference to non-existent `feedItem.link` in the `console.error` statement.

This PR does the following:

1. Patches the error message so that the build process doesn't fail (error messages related to failed URL fetches are still displayed in the console)
2. Provides minor tweaks to README so that it's possible to quickly test the plugin.

Let me know what you think. Thanks!